### PR TITLE
FEAT: Add zoom and pan with also auto height full support

### DIFF
--- a/streamlit_mermaid/__init__.py
+++ b/streamlit_mermaid/__init__.py
@@ -1,4 +1,5 @@
 import os
+from typing import Optional
 
 import streamlit as st
 import streamlit.components.v1 as components
@@ -18,8 +19,8 @@ else:
     _streamlit_mermaid = components.declare_component("streamlit_mermaid", path=build_dir)
 
 
-def st_mermaid(code: str, width="auto", height="250px", key=None):
-    return _streamlit_mermaid(code=code, width=width, height=height, key=key)
+def st_mermaid(code: str, width: str="auto", height: str="auto", pan: bool=True, zoom: bool=True, show_controls: bool=True, key: Optional[str]=None):
+    return _streamlit_mermaid(code=code, width=width, height=height, pan=pan, zoom=zoom, show_controls=show_controls, key=key)
 
 
 # Test code to play with the component while it's in development.
@@ -32,6 +33,7 @@ if not _RELEASE:
         B --> C
         C --> D
         D --> E
+        D --> F
     """
 
-    st_mermaid(code)
+    st_mermaid(code, height="auto", pan=True, zoom=True, show_controls=True)

--- a/streamlit_mermaid/frontend/package.json
+++ b/streamlit_mermaid/frontend/package.json
@@ -14,6 +14,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",
+    "svg-pan-zoom": "^3.6.1",
     "streamlit-component-lib": "2.0.0",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"

--- a/streamlit_mermaid/frontend/src/MermaidViewer.tsx
+++ b/streamlit_mermaid/frontend/src/MermaidViewer.tsx
@@ -1,31 +1,70 @@
-import React, { useRef, useEffect, ReactElement } from "react"
+import React, { useRef, useEffect, ReactElement } from "react";
 import {
   withStreamlitConnection,
   Streamlit,
   ComponentProps,
-} from "streamlit-component-lib"
-import mermaid from 'mermaid';
+} from "streamlit-component-lib";
+import mermaid from "mermaid";
+import svgPanZoom from "svg-pan-zoom";
 
-
-function MermaidViwer({args}: ComponentProps): ReactElement {
+function MermaidViwer({ args }: ComponentProps): ReactElement {
   const ref = useRef<HTMLDivElement>(null);
-  const { code, width, height } = args;
+  const { code, width, height, pan, zoom, show_controls } = args;
 
   useEffect(() => {
     Streamlit.setFrameHeight();
-  })
+  });
 
   useEffect(() => {
     if (ref.current) {
-      mermaid.mermaidAPI.render('graphDiv', code).then((svgGraph) => {
+      mermaid.mermaidAPI.render("graphDiv", code).then((svgGraph) => {
         if (ref.current) {
           ref.current.innerHTML = svgGraph.svg;
+
+          if (pan || zoom) {
+            svgPanZoom("#graphDiv", {
+              viewportSelector: ".svg-pan-zoom_viewport",
+              panEnabled: pan,
+              controlIconsEnabled: show_controls,
+              zoomEnabled: zoom,
+              dblClickZoomEnabled: zoom,
+              mouseWheelZoomEnabled: zoom,
+              preventMouseEventsDefault: true,
+              zoomScaleSensitivity: 0.2,
+              minZoom: 0.5,
+              maxZoom: 10,
+              fit: true,
+              contain: false,
+              center: false,
+              refreshRate: "auto",
+            });
+          }
+          
+          var graph = document.getElementById("graphDiv");
+          if (graph) {
+            var svgs = document.getElementsByClassName("svg-pan-zoom_viewport");
+            if (svgs.length > 0) {
+            var svg = svgs[0];
+            var bbox = svg.getBoundingClientRect();
+          } else {
+            bbox = graph.getBoundingClientRect();
+          }
+          graph.setAttribute("height", "" + (bbox.height + 16));
+          if (height === "auto") {
+            Streamlit.setFrameHeight(bbox.height + 16);
+          }
         }
+      }
       });
     }
-  }, [code]);
+  }, [code, height, pan, zoom, show_controls]);
 
-  return <div ref={ref} style={{width: width, height: height, overflow: "auto"}} ></div>;
+  return (
+    <div
+      ref={ref}
+      style={{ width: width, height: height, overflow: "auto" }}
+    ></div>
+  );
 }
 
-export default withStreamlitConnection(MermaidViwer)
+export default withStreamlitConnection(MermaidViwer);


### PR DESCRIPTION
In this PR it is added support for pan and zoom using [SVG pan zoom](https://github.com/bumbu/svg-pan-zoom) library. Besides, it is supported to have `auto` height to adapt to the SVG to always show it completely.