### PR TITLE
Unrestrict setuptools version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ packages = [{include = "streamlit_mermaid"}]
 python = "^3.9"
 streamlit = "^1.0.0"
 altair = "<5"
-setuptools = "^75.6.0"
+setuptools = ">=75.6.0"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Remove unnecessary version restriction from setuptools. Earlier versions of setuptools have [security vulnerabilities](https://huntr.com/bounties/d6362117-ad57-4e83-951f-b8141c6e7ca5) and this project still works as expected when using the most recent version of setuptools.